### PR TITLE
Synchronize logToFile

### DIFF
--- a/logger/src/main/java/org/unfoldingword/tools/logger/Logger.java
+++ b/logger/src/main/java/org/unfoldingword/tools/logger/Logger.java
@@ -241,7 +241,7 @@ public class Logger {
      * @param logMessageTag A tag identifying a group of log messages.
      * @param logMessage The message to add to the log.
      */
-    private void logToFile(LogLevel level, String logMessageTag, String logMessage) {
+    private synchronized void logToFile(LogLevel level, String logMessageTag, String logMessage) {
         // filter out logging levels
         if (level.getIndex() >= mMinLoggingLevel.getIndex() && mLogFile != null) {
             try {


### PR DESCRIPTION
Synchronizes calls to logToFile so that threads that are writing to the log file do not interfere with one another (they can at the very least cause FileNotFound Exceptions if one thread executes line 257 (delete) while another is trying to write).
